### PR TITLE
Add a `to_browser` method for `ViewerState`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 This project attempts to follow [Semantic Versioning](https://semver.org) and uses [Keep-a-Changelog formatting](https://keepachangelog.com/en/1.0.0/). But I make mistakes sometimes.
 
+## [x.x.x] - YYYY-MM-DD
+
+### Added
+
+- **StateBuilder**: Added `ViewerState.to_browser` method that parallels `ViewerState.to_url` that opens a URL in the browser (h/t Ben Pedigo)
+
 ## [4.4.1] - 2025-07-01
 
 ### Fixed
@@ -12,7 +18,7 @@ This project attempts to follow [Semantic Versioning](https://semver.org) and us
 
 ### Added
 
-- **StateBuilder**: Added `ViewerState.to_clipboard` method that parallels `ViewerState.to_link` that copies the URL or shortened link to the clipboard (h/t Ben Pedigo)
+- **StateBuilder**: Added `ViewerState.to_clipboard` method that parallels `ViewerState.to_url` that copies the URL or shortened link to the clipboard (h/t Ben Pedigo)
 
 ### Fixed
 

--- a/docs/usage/statebuilder.md
+++ b/docs/usage/statebuilder.md
@@ -130,6 +130,20 @@ will upload the state and return a short link with a form like `'https://spelunk
 You can also use the link shortener in the `to_url` and `to_link` methods by setting the `shorten` argument to `True` or `if_long` and passing a CAVEclient object.
 The `if_long` option will only shorten the url if it gets long enough to start breaking the URL length limits of most browsers, approximately 1.75 million characters.
 
+There are also convenience functions for copying the URL to the clipboard or opening it in a web browser, both of which have similar paramaters as the `to_url` method.
+
+The [to_clipboard](../reference/statebuilder.md#src.nglui.statebuilder.base.ViewerState.to_clipboard) method will copy the URL to your system clipboard, after passing through the link shortener:
+
+```py
+viewerstate.to_clipboard(shorten=True, client=client)
+```
+
+And the [to_browser](../reference/statebuilder.md#src.nglui.statebuilder.base.ViewerState.to_browser) method will open the URL in your the web browser of your choosing, again after passing through the link shortener:
+
+```py
+viewerstate.to_browser(shorten=True, client=client, browser='firefox')
+```
+
 To change the Neuroglancer web deployment used in all of the url and link functions, you can set a different URL in the `target_url` parameter of the `to_url` function.
 For example, to use the default Neuroglancer deployment, you can do:
 

--- a/src/nglui/statebuilder/base.py
+++ b/src/nglui/statebuilder/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import warnings
+import webbrowser
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
@@ -13,9 +14,9 @@ except ImportError:
 
 import neuroglancer
 import numpy as np
+import pyperclip
 from IPython.display import HTML
 from neuroglancer import viewer, viewer_base
-import pyperclip
 
 from . import source_info
 from .ngl_components import (
@@ -1381,7 +1382,7 @@ class ViewerState:
         Returns
         -------
         str
-            The URL representation of the viewer state that has also been copied to the 
+            The URL representation of the viewer state that has also been copied to the
             clipboard.
         """
         url = self.to_url(
@@ -1391,4 +1392,62 @@ class ViewerState:
             client=client,
         )
         pyperclip.copy(url)
+        return url
+
+    def to_browser(
+        self,
+        target_url: str = None,
+        target_site: str = None,
+        shorten: Union[bool, Literal["if_long"]] = False,
+        client: Optional["caveclient.CAVEclient"] = None,
+        new: int = 2,
+        autoraise: bool = True,
+        browser: Optional[str] = None,
+    ):
+        """Open the viewer state URL in a web browser.
+
+        Parameters
+        ----------
+        target_url : str
+            The base URL to use for the Neuroglancer state. If not provided,
+            the default server URL will be used.
+        target_site : str, optional
+            The target site for the URL, based on the keys in site_utils.NEUROGLANCER_SITES.
+            If not provided, the default server URL will be used.
+        shorten: Union[bool, Literal["if_long"]], optional
+            If True, the URL will be shortened using the CAVE link shortener service.
+            If "if_long", the URL will only be shortened if it exceeds a certain length.
+        client : Optional[caveclient.CAVEclient], optional
+            The CAVE client to use for shortening the URL. If not provided, the URL will not be shortened.
+        new : int, optional
+            If new is 0, the url is opened in the same browser window if possible. If 
+            new is 1, a new browser window is opened if possible. If new is 2, a new 
+            browser page (“tab”) is opened if possible. Note that not all browsers
+            support all values of new, and some may ignore this parameter.
+        autoraise : bool, optional
+            If True, the browser window will be raised to the front when opened. Note 
+            that under many window managers this will occur regardless of the setting 
+            of this variable.
+        browser : Optional[str], optional
+            The name of the browser to use. If None, the system default browser will be
+            used. Note that the browser name needs to be registered on your system,
+            see [webbrowser documentation](https://docs.python.org/3/library/webbrowser.html#webbrowser.register) for more details.
+
+        Returns
+        -------
+        str
+            The URL representation of the viewer state that has also been opened in the
+            browser.
+        """
+        url = self.to_url(
+            target_url=target_url,
+            target_site=target_site,
+            shorten=shorten,
+            client=client,
+        )
+        if browser is None:
+            webbrowser.open(url, new=new, autoraise=autoraise)
+        else: 
+            browser_controller = webbrowser.get(browser)
+            browser_controller.open(url, new=new, autoraise=autoraise)
         return url

--- a/src/nglui/statebuilder/base.py
+++ b/src/nglui/statebuilder/base.py
@@ -1431,7 +1431,11 @@ class ViewerState:
         browser : Optional[str], optional
             The name of the browser to use. If None, the system default browser will be
             used. Note that the browser name needs to be registered on your system,
-            see [webbrowser documentation](https://docs.python.org/3/library/webbrowser.html#webbrowser.register) for more details.
+            see [webbrowser.register][] for more details.
+
+        See Also
+        --------
+        [webbrowser.open][] : Opens a URL in the web browser.
 
         Returns
         -------

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
@@ -519,11 +520,13 @@ class TestViewerStateNeuroglancerConversion:
         with patch.object(vs, "to_json_string") as mock_to_json:
             mock_to_json.return_value = '{"test": "state"}'
 
-            url = vs.to_clipboard()
+            # need additional installs for linux clipboard support
+            if sys.platform != "linux":
+                url = vs.to_clipboard()
 
-            # Just check that a URL is returned
-            assert isinstance(url, str)
-            assert len(url) > 0
+                # Just check that a URL is returned
+                assert isinstance(url, str)
+                assert len(url) > 0
 
     def test_to_browser(self):
         vs = ViewerState()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -513,6 +513,30 @@ class TestViewerStateNeuroglancerConversion:
             assert "12345" in str(url)
             mock_client.state.upload_state_json.assert_called_once()
 
+    def test_to_clipboard(self):
+        vs = ViewerState()
+
+        with patch.object(vs, "to_json_string") as mock_to_json:
+            mock_to_json.return_value = '{"test": "state"}'
+
+            url = vs.to_clipboard()
+
+            # Just check that a URL is returned
+            assert isinstance(url, str)
+            assert len(url) > 0
+
+    def test_to_browser(self):
+        vs = ViewerState()
+
+        with patch.object(vs, "to_json_string") as mock_to_json:
+            mock_to_json.return_value = '{"test": "state"}'
+
+            url = vs.to_browser()
+
+            # Just check that a URL is returned
+            assert isinstance(url, str)
+            assert len(url) > 0
+
 
 class TestViewerStateValidation:
     def test_viewer_property_lazy_loading(self):


### PR DESCRIPTION
- on my system the new/autoraise flags didn't seem to be doing anything, as the webbrower docs suggested they might, but I left them in. up for discussion
- the current test does in fact raise a browser window, can remove if that'd be annoying for local testing